### PR TITLE
fix/index out of range

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -350,7 +350,7 @@ func (r *GatewayService) performTransaction(req *request.GatewayRequest,
 		if hostList == nil {
 			serverList = make([]string, 2)
 			serverList[0] = _ROCKETGATE_GW16_STRING
-			serverList[2] = _ROCKETGATE_GW17_STRING
+			serverList[1] = _ROCKETGATE_GW17_STRING
 		} else {
 			serverList = make([]string, len(hostList))
 			for i := 0; i < len(hostList); i++ {


### PR DESCRIPTION
When lookup failed, the second element was incorrectly assigned to
index 2 instead of index 1. This caused a fatal panic when the array
was accessed, since the serverList was initialized with a length of 2.